### PR TITLE
Mimemagic 0.3.3 yanked version to 0.3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)


### PR DESCRIPTION
- Mimemagic 0.3.3 on Gemfile.lock is been yanked by the author.
- Gemfile.lock updated to mimemagic 0.3.10.